### PR TITLE
Used secrets for username/password of existing DB/MQ, license and keystore files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Helm Charts for Digital.ai Release Changelog
 All changes to this chart will be documented in this file
 
+## [1.1.3]
+* Use secrets for username/password for both existing MQ/DB, license and keystore files
+
 ## [1.1.2]
 * Add support for Azure AKS
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v9.7
 description: A Helm chart for XL Release
 name: xl-release-helmcharts
-version: 1.1.2-alpha
+version: 1.1.3-alpha
 
 dependencies:
 - name: haproxy-ingress

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -5,13 +5,13 @@ http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
 {{- end }}
 {{- end }}
 
-## To get the admin password for xl-release, run:
-kubectl get secret --namespace {{ .Release.Namespace }} {{ include "xl-release.fullname" . }} -o jsonpath="{.data.release-password}" | base64 --decode; echo
-{{ if .Values.postgresql.install }}
+{{- if .Values.postgresql.install }}
 ## To get the password for postgresql, run:
-kubectl get secret {{ .Release.Name }}-postgresql -o jsonpath="{.data.postgresql-password}" | base64 --decode; echo
+kubectl get secret --namespace  {{ .Release.Namespace }} {{ .Release.Name }}-postgresql -o jsonpath="{.data.postgresql-password}" | base64 --decode; echo
 {{ end }}
-{{- if .Values.rabbitmq.install }}
 ## To get the password for rabbitMQ, run:
-kubectl get secret {{ .Release.Name }}-rabbitmq  -o jsonpath="{.data.rabbitmq-password}" | base64 --decode; echo
+{{- if .Values.rabbitmq.install }}
+kubectl get secret --namespace  {{ .Release.Namespace }} {{ .Release.Name }}-rabbitmq   -o jsonpath="{.data.rabbitmq-password}" | base64 --decode; echo
+{{- else }}
+kubectl get secret --namespace {{ .Release.Namespace }} {{ include "xl-release.fullname" . }} -o jsonpath="{.data.rabbitmqPassword}" | base64 --decode; echo
 {{- end }}

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -7,7 +7,7 @@ http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
 
 ## To get the admin password for xl-release, run:
 kubectl get secret --namespace {{ .Release.Namespace }} {{ include "xl-release.fullname" . }} -o jsonpath="{.data.release-password}" | base64 --decode; echo
-{{- if .Values.postgresql.install }}
+{{ if .Values.postgresql.install }}
 ## To get the password for postgresql, run:
 kubectl get secret --namespace  {{ .Release.Namespace }} {{ .Release.Name }}-postgresql -o jsonpath="{.data.postgresql-password}" | base64 --decode; echo
 {{ end }}

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -5,6 +5,8 @@ http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
 {{- end }}
 {{- end }}
 
+## To get the admin password for xl-release, run:
+kubectl get secret --namespace {{ .Release.Namespace }} {{ include "xl-release.fullname" . }} -o jsonpath="{.data.release-password}" | base64 --decode; echo
 {{- if .Values.postgresql.install }}
 ## To get the password for postgresql, run:
 kubectl get secret --namespace  {{ .Release.Namespace }} {{ .Release.Name }}-postgresql -o jsonpath="{.data.postgresql-password}" | base64 --decode; echo

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -14,3 +14,22 @@ data:
   {{ else }}
   release-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{ end }}
+  {{ if .Values.xlrLicense }}
+  xlr-License: {{ .Values.xlrLicense | b64enc | quote }}
+  {{ end }}
+  {{ if .Values.RepositoryKeystore }}
+  repositoryKeystore: {{ .Values.RepositoryKeystore | b64enc | quote }}
+  {{ end }}
+  {{ if .Values.KeystorePassphrase }}
+  keystorePassphrase: {{ .Values.KeystorePassphrase | b64enc | quote }}
+  {{ end }}
+  {{ if .Values.UseExistingDB.Enabled }}
+  databaseUsername: {{ .Values.UseExistingDB.XLR_DB_USER | b64enc | quote }}
+  databasePassword: {{ .Values.UseExistingDB.XLR_DB_PASS | b64enc | quote }}
+  reportDatabaseUsername: {{ .Values.UseExistingDB.XLR_REPORT_DB_USER | b64enc | quote }}
+  reportDatabasePassword: {{ .Values.UseExistingDB.XLR_REPORT_DB_PASS | b64enc | quote }}
+  {{ end }}
+  {{ if .Values.UseExistingMQ.Enabled }}
+  rabbitmqUsername: {{ .Values.UseExistingMQ.XLR_TASK_QUEUE_USERNAME | b64enc | quote }}
+  rabbitmqPassword: {{ .Values.UseExistingMQ.XLR_TASK_QUEUE_PASSWORD | b64enc | quote }}
+  {{ end }}

--- a/templates/xl-release.yaml
+++ b/templates/xl-release.yaml
@@ -91,19 +91,34 @@ spec:
             - name: XL_DB_URL
               value: {{ .Values.UseExistingDB.XLR_DB_URL }}
             - name: XL_DB_USERNAME
-              value: {{ .Values.UseExistingDB.XLR_DB_USER }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "xl-release.fullname" . }}
+                  key: databaseUsername              
             - name: XL_DB_PASSWORD
-              value: {{ .Values.UseExistingDB.XLR_DB_PASS }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "xl-release.fullname" . }}
+                  key: databasePassword
             - name: XL_REPORT_DB_URL
               value: {{ .Values.UseExistingDB.XLR_REPORT_DB_URL }}
             - name: XL_REPORT_DB_USERNAME
-              value: {{ .Values.UseExistingDB.XLR_REPORT_DB_USER }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "xl-release.fullname" . }}
+                  key: reportDatabaseUsername
             - name: XL_REPORT_DB_PASSWORD
-              value: {{ .Values.UseExistingDB.XLR_REPORT_DB_PASS }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "xl-release.fullname" . }}
+                  key: reportDatabasePassword
             {{- end }}
             {{- end }}
             - name: XL_LICENSE
-              value: {{ .Values.xlrLicense }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "xl-release.fullname" . }}
+                  key: xlr-License
             - name: XL_METRICS_ENABLED
               value: "false"
             - name: FORCE_UPGRADE
@@ -125,9 +140,15 @@ spec:
             {{- else }}
             {{- if .Values.UseExistingMQ.Enabled }}
             - name: XLR_TASK_QUEUE_USERNAME
-              value: {{ .Values.UseExistingMQ.XLR_TASK_QUEUE_USERNAME }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "xl-release.fullname" . }}
+                  key: rabbitmqUsername
             - name: XLR_TASK_QUEUE_PASSWORD
-              value: {{ .Values.UseExistingMQ.XLR_TASK_QUEUE_PASSWORD | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "xl-release.fullname" . }}
+                  key: rabbitmqPassword
             - name: XLR_TASK_QUEUE_URL
               value: {{ .Values.UseExistingMQ.XLR_TASK_QUEUE_URL | quote }}
             - name: XLR_TASK_QUEUE_NAME
@@ -135,9 +156,15 @@ spec:
             {{- end }}
             {{- end }}
             - name: REPOSITORY_KEYSTORE
-              value: {{ .Values.RepositoryKeystore }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "xl-release.fullname" . }}
+                  key: repositoryKeystore
             - name: REPOSITORY_KEYSTORE_PASSPHRASE
-              value: {{ .Values.KeystorePassphrase }}  
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "xl-release.fullname" . }}
+                  key: keystorePassphrase  
           resources:
 {{ toYaml .Values.resources | indent 12 }}
       volumes:


### PR DESCRIPTION
1. Secrets are used for Postgres username/password
2. Secrets are used for RabbitMQ username/password
3. Secrets are used for XLR License and KeystorePassphrase



