### PR TITLE
Persist the data for various folders exposed as mount points for Release 10.2 openshift.

### DIFF
--- a/templates/xl-release.yaml
+++ b/templates/xl-release.yaml
@@ -50,6 +50,28 @@ spec:
           volumeMounts:
             - name: reports-dir
               mountPath: /opt/xebialabs/xl-release-server/reports
+              subPath: reports
+            - name: reports-dir
+              mountPath: /opt/xebialabs/xl-release-server/work
+              subPath: work
+            - name: reports-dir
+              mountPath: /opt/xebialabs/xl-release-server/log
+              subPath: log
+            - name: reports-dir
+              mountPath: /opt/xebialabs/xl-release-server/conf
+              subPath: conf
+            - name: reports-dir
+              mountPath: /opt/xebialabs/xl-release-server/ext
+              subPath: ext
+            - name: reports-dir
+              mountPath: /opt/xebialabs/xl-release-server/hotfix
+              subPath: hotfix
+            - name: reports-dir
+              mountPath: /opt/xebialabs/xl-release-server/hotfix/lib
+              subPath: lib
+            - name: reports-dir
+              mountPath: /opt/xebialabs/xl-release-server/hotfix/plugins
+              subPath: plugins 
           {{- if .Values.HealthProbes }}
           readinessProbe:
             httpGet:
@@ -181,9 +203,7 @@ spec:
             claimName: {{ template "xl-release.fullname" . }}
         {{- else }}
         - name: reports-dir
-          hostPath:
-            path: /opt/xebialabs/xl-release-server/reports
-            type: DirectoryOrCreate
+          emptyDir: {}
         {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/values.yaml
+++ b/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 3
 ## XL-Release image version
 ## Ref: https://hub.docker.com/r/xebialabs/xl-release/tags
 ImageRepository: "xebialabs/xl-release"
-ImageTag: "10.1"
+ImageTag: "10.2"
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if image tag is 'latest',set to 'IfNotPresent'


### PR DESCRIPTION
Persist the data for various folders exposed as mount points for Release 10.2 openshift.
https://digitalai.atlassian.net/browse/ENG-6406
Updated the xl-release.yaml file and added various folders as shared data.