### PR TITLE
ENG-9377-oc-22.1  Refresh xebialabs/tiny-tools image version

### DIFF
--- a/templates/xl-release.yaml
+++ b/templates/xl-release.yaml
@@ -32,7 +32,7 @@ spec:
       {{- if .Values.postgresql.install }}
       initContainers:
         - name: wait-for-db
-          image: xebialabs/tiny-tools
+          image: "{{ .Values.TinyToolsImageRepository }}:{{ .Values.TinyToolsImageTag }}"
           command:
             - sh
             - -c

--- a/values.yaml
+++ b/values.yaml
@@ -10,6 +10,11 @@ replicaCount: 3
 ImageRepository: "xebialabs/xl-release"
 ImageTag: "22.0"
 
+## xebialabs/tiny-tools image version
+## Ref: https://hub.docker.com/r/xebialabs/tiny-tools/tags
+TinyToolsImageRepository: "xebialabs/tiny-tools"
+TinyToolsImageTag: "22.2.0"
+
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if image tag is 'latest',set to 'IfNotPresent'
 ImagePullPolicy: "Always"


### PR DESCRIPTION
* ENG-9236-oc Refresh xebialabs/tiny-tools image version

* ENG-9236 updated the tiny-tools version to 22.2.0

* ENG-9236 updated the tiny-tools repository